### PR TITLE
Template :html for :if/:else and :scope rework

### DIFF
--- a/directive/html.js
+++ b/directive/html.js
@@ -10,7 +10,7 @@ import sprae, { untracked, frag, _dispose, _state } from "../core.js"
 export default (el, state) => {
   // <template :html="a"/> - fragment case: use placeholder + frag
   if (el.content) {
-    let _el, html = '',
+    let _el, html = el.innerHTML,
       doc = el.ownerDocument,
       holder = el._holder
 

--- a/directive/html.js
+++ b/directive/html.js
@@ -1,4 +1,4 @@
-import sprae, { _dispose } from "../core.js"
+import sprae, { untracked, _dispose, _state } from "../core.js"
 
 /**
  * HTML directive - sets innerHTML and initializes nested directives.
@@ -27,5 +27,5 @@ export default (el, state) => {
       }
     }
   }
-  return v => (v = typeof v === 'function' ? v(el.innerHTML) : v, el.innerHTML = v == null ? "" : v, sprae(el, state), el[_dispose])
+  return v => (v = typeof v === 'function' ? v(el.innerHTML) : v, el.innerHTML = v == null ? "" : v, el[_state] &&= null, untracked(() => sprae(el, state)), el[_dispose])
 }

--- a/directive/scope.js
+++ b/directive/scope.js
@@ -13,8 +13,8 @@ export default (el, rootState) => {
   let state = el[_state] = store({}, rootState), init = false
 
   // <template :scope="{}" /> or previously initialized template
-  let _el = el.content ? frag(el) : el, _holder
-  if (el.content) el.replaceWith(_holder = el.ownerDocument.createTextNode(''))
+  let holder, _frag = el.content && frag(el)
+  if (_frag) el.replaceWith(holder = el.ownerDocument.createTextNode(''))
 
   // 1st run spraes subtree with values from scope, it can be postponed by modifiers (we isolate reads from parent effect)
   // 2nd+ runs update subscope
@@ -35,6 +35,6 @@ export default (el, rootState) => {
     }
 
     // Object.assign(subscope, call(values, subscope))
-    return !init && (init = true, delete el[_state], untracked(() => (_holder?.before(_el.content || _el), sprae(_el, state))))
+    return !init && (init = true, !holder && (delete el[_state]), untracked(() => (holder?.before(_frag.content || el), sprae(_frag || el, state))))
   }
 }

--- a/store.js
+++ b/store.js
@@ -221,7 +221,7 @@ const create = (signals, k, v) => (signals[k] = (k[0] == '_' || v?.peek) ? v : s
 const set = (signals, k, v, _s, _v) => {
   // skip unchanged (although can be handled by last condition - we skip a few checks this way)
   return k[0] === '_' ? (signals[k] = v) :
-    (v !== (_v = (_s = signals[k]).peek())) && (
+    (v !== (_v = (_s = signals[k]).peek?.() ?? _s)) && (
       // stashed _set for value with getter/setter
       _s[_set] ? _s[_set](v) :
         // patch array

--- a/test/directive/html.js
+++ b/test/directive/html.js
@@ -42,23 +42,23 @@ test("html: fragment", async () => {
 
 test("html: function", async () => {
   // jessie: causes hang after test completion
-  let el = h`<div :html="h => h + suffix"></div>`;
+  let el = h`<div :html="h => h + suffix"><a>!</a></div>`;
   let params = sprae(el, { suffix: '!' });
-  is(el.outerHTML, `<div>!</div>`);
+  is(el.innerHTML, `<a>!</a>!`);
   params.suffix = '<b>!</b>';
   await tick();
-  is(el.outerHTML, `<div>!<b>!</b></div>`);
+  is(el.innerHTML, `<a>!</a>!<b>!</b>`);
 });
 
 
 test("html: fragment function", async () => {
   // jessie: causes hang after test completion
-  let el = h`<div><template :html="h => h + suffix"></template></div>`;
+  let el = h`<div><template :html="h => h + suffix"><a>!</a></template></div>`;
   let params = sprae(el, { suffix: '!' });
-  is(el.innerHTML, `!`);
+  is(el.innerHTML, `<a>!</a>!`);
   params.suffix = '<b>!</b>';
   await tick();
-  is(el.innerHTML, `!<b>!</b>`);
+  is(el.innerHTML, `<a>!</a>!<b>!</b>`);
 });
 
 test("html: nested sprae elements", async () => {

--- a/test/directive/html.js
+++ b/test/directive/html.js
@@ -31,6 +31,15 @@ test("html: null/empty", async () => {
   is(el.outerHTML, `<div></div>`);
 });
 
+test("html: fragment", async () => {
+  let el = h`a<template :html="html"/>`;
+  let params = sprae(el, { html: "<b>b</b>" });
+  is(el.outerHTML, `a<b>b</b>`);
+  params.html = '<i>c</i>';
+  await tick();
+  is(el.outerHTML, `a<i>c</i>`);
+});
+
 test("html: function", async () => {
   // jessie: causes hang after test completion
   let el = h`<div :html="h => h + suffix"></div>`;
@@ -41,13 +50,15 @@ test("html: function", async () => {
   is(el.outerHTML, `<div>!<b>!</b></div>`);
 });
 
-test("html: fragment", async () => {
-  let el = h`a<template :html="html"/>`;
-  let params = sprae(el, { html: "<b>b</b>" });
-  is(el.outerHTML, `a<b>b</b>`);
-  params.html = '<i>c</i>';
+
+test("html: fragment function", async () => {
+  // jessie: causes hang after test completion
+  let el = h`<div><template :html="h => h + suffix"></template></div>`;
+  let params = sprae(el, { suffix: '!' });
+  is(el.innerHTML, `!`);
+  params.suffix = '<b>!</b>';
   await tick();
-  is(el.outerHTML, `a<i>c</i>`);
+  is(el.innerHTML, `!<b>!</b>`);
 });
 
 test("html: nested sprae elements", async () => {
@@ -78,6 +89,18 @@ test("html: with condition", async () => {
   params.show = true;
   await tick();
   is(el.innerHTML, `<span><b>content</b></span>`);
+});
+
+test("html: fragment with condition", async () => {
+  let el = h`<div><template :if="show" :html="html"></template></div>`;
+  let params = sprae(el, { show: true, html: '<b>content</b>' });
+  is(el.innerHTML, `<b>content</b>`);
+  params.show = false;
+  await tick();
+  is(el.innerHTML, ``);
+  params.show = true;
+  await tick();
+  is(el.innerHTML, `<b>content</b>`);
 });
 
 test("html: special characters", async () => {

--- a/test/directive/html.js
+++ b/test/directive/html.js
@@ -130,3 +130,23 @@ test("html: doesnt get side-triggered", async () => {
   state.bool = true
   is(state._log, 1)
 })
+
+test("html: with :scope", async () => {
+  let el = h`<div><div :scope="{ bar: 'bar' }" :html="html"></div></div>`;
+  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
+  await tick();
+  is(el.innerHTML, `<div><a>foobar</a></div>`);
+  s.foo = "moo";
+  await tick();
+  is(el.innerHTML, `<div><a>moobar</a></div>`);
+})
+
+test("html: fragment with :scope", async () => {
+  let el = h`<div><template :scope="{ bar: 'bar' }" :html="html"></template></div>`;
+  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
+  await tick();
+  is(el.innerHTML, `<a>foobar</a>`);
+  s.foo = "moo";
+  await tick();
+  is(el.innerHTML, `<a>moobar</a>`);
+})

--- a/test/directive/scope.js
+++ b/test/directive/scope.js
@@ -137,3 +137,13 @@ test("scope: fragment", async () => {
   await tick();
   is(el.outerHTML, `a<y>foobaz</y>`);
 });
+
+test("scope: with :html", async () => {
+  let el = h`<div><div :scope="{ bar: 'bar' }" :html="html"></div></div>`;
+  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
+  await tick();
+  is(el.innerHTML, `<div><a>foobar</a></div>`);
+  s.foo = "moo";
+  await tick();
+  is(el.innerHTML, `<div><a>moobar</a></div>`);
+})

--- a/test/directive/scope.js
+++ b/test/directive/scope.js
@@ -140,10 +140,20 @@ test("scope: fragment", async () => {
 
 test("scope: with :html", async () => {
   let el = h`<div><div :scope="{ bar: 'bar' }" :html="html"></div></div>`;
-  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
+  let s = sprae(el, { show: true, foo: "foo", html: `<a :text="foo+bar"></a>` });
   await tick();
   is(el.innerHTML, `<div><a>foobar</a></div>`);
   s.foo = "moo";
   await tick();
   is(el.innerHTML, `<div><a>moobar</a></div>`);
+})
+
+test("scope: fragment with :html", async () => {
+  let el = h`<div><template :scope="{ bar: 'bar' }" :html="html"></template></div>`;
+  let s = sprae(el, { show: true, foo: "foo", html: `<a :text="foo+bar"></a>` });
+  await tick();
+  is(el.innerHTML, `<a>foobar</a>`);
+  s.foo = "moo";
+  await tick();
+  is(el.innerHTML, `<a>moobar</a>`);
 })

--- a/test/directive/scope.js
+++ b/test/directive/scope.js
@@ -138,26 +138,6 @@ test("scope: fragment", async () => {
   is(el.outerHTML, `a<y>foobaz</y>`);
 });
 
-test("scope: with :html", async () => {
-  let el = h`<div><div :scope="{ bar: 'bar' }" :html="html"></div></div>`;
-  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
-  await tick();
-  is(el.innerHTML, `<div><a>foobar</a></div>`);
-  s.foo = "moo";
-  await tick();
-  is(el.innerHTML, `<div><a>moobar</a></div>`);
-})
-
-test("scope: fragment with :html", async () => {
-  let el = h`<div><template :scope="{ bar: 'bar' }" :html="html"></template></div>`;
-  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
-  await tick();
-  is(el.innerHTML, `<a>foobar</a>`);
-  s.foo = "moo";
-  await tick();
-  is(el.innerHTML, `<a>moobar</a>`);
-})
-
 test("scope: with :fx", async () => {
   let el = h`<div><div :scope="{ bar: 'bar' }" :fx="() => ut(() => { count += 1 })"></div></div>`;
   let params = sprae(el, { count: 0, ut: untracked });

--- a/test/directive/scope.js
+++ b/test/directive/scope.js
@@ -140,7 +140,7 @@ test("scope: fragment", async () => {
 
 test("scope: with :html", async () => {
   let el = h`<div><div :scope="{ bar: 'bar' }" :html="html"></div></div>`;
-  let s = sprae(el, { show: true, foo: "foo", html: `<a :text="foo+bar"></a>` });
+  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
   await tick();
   is(el.innerHTML, `<div><a>foobar</a></div>`);
   s.foo = "moo";
@@ -150,10 +150,24 @@ test("scope: with :html", async () => {
 
 test("scope: fragment with :html", async () => {
   let el = h`<div><template :scope="{ bar: 'bar' }" :html="html"></template></div>`;
-  let s = sprae(el, { show: true, foo: "foo", html: `<a :text="foo+bar"></a>` });
+  let s = sprae(el, { foo: "foo", html: `<a :text="foo+bar"></a>` });
   await tick();
   is(el.innerHTML, `<a>foobar</a>`);
   s.foo = "moo";
   await tick();
   is(el.innerHTML, `<a>moobar</a>`);
 })
+
+test("scope: with :fx", async () => {
+  let el = h`<div><div :scope="{ bar: 'bar' }" :fx="() => ut(() => { count += 1 })"></div></div>`;
+  let params = sprae(el, { count: 0, ut: untracked });
+  await tick()
+  is(params.count, 1);
+});
+
+test("scope: fragment with :fx", async () => {
+  let el = h`<div><template :scope="{ bar: 'bar' }" :fx="() => ut(() => { count += 1 })"></template></div>`;
+  let params = sprae(el, { count: 0, ut: untracked });
+  await tick()
+  is(params.count, 1);
+});


### PR DESCRIPTION
Hi !

After some days, I have finally fullfiled this `template :html` rework.

It does now fully support : 
- `:if`/`:else`
- `:scope`
- `:html` function

I have also fixed an issue on `template :scope` that made the directives run twice. Once on rootScope then on scope.

And there are two fixes for preact based signals. That made the `:scope :html` fails.

What do you think of it ? 